### PR TITLE
wait for stream close event before callback

### DIFF
--- a/src/validators/excessiveRolesTR/index.js
+++ b/src/validators/excessiveRolesTR/index.js
@@ -125,5 +125,5 @@ module.exports = function (tags, pbfFile, outputFile, callback) {
   handlerB.end()
   handlerC.end()
   wstream.end()
-  callback()
+  wstream.on('close', callback)
 }

--- a/src/validators/filterTRByCommunity/index.js
+++ b/src/validators/filterTRByCommunity/index.js
@@ -120,5 +120,5 @@ module.exports = function (opts, pbfFile, outputFile, callback) {
   handlerB.end()
   handlerC.end()
   wstream.end()
-  callback()
+  wstream.on('close', callback)
 }

--- a/src/validators/filterTRByUsers/index.js
+++ b/src/validators/filterTRByUsers/index.js
@@ -113,5 +113,5 @@ module.exports = function (opts, pbfFile, outputFile, callback) {
   handlerB.end()
   handlerC.end()
   wstream.end()
-  callback()
+  wstream.on('close', callback)
 }

--- a/src/validators/invalidRoleTR/index.js
+++ b/src/validators/invalidRoleTR/index.js
@@ -123,5 +123,5 @@ module.exports = function (tags, pbfFile, outputFile, callback) {
   handlerB.end()
   handlerC.end()
   wstream.end()
-  callback()
+  wstream.on('close', callback)
 }

--- a/src/validators/missingRoleTR/index.js
+++ b/src/validators/missingRoleTR/index.js
@@ -122,5 +122,5 @@ module.exports = function (tags, pbfFile, outputFile, callback) {
   handlerB.end()
   handlerC.end()
   wstream.end()
-  callback()
+  wstream.on('close', callback)
 }

--- a/src/validators/missingTypeRestrictionTR/index.js
+++ b/src/validators/missingTypeRestrictionTR/index.js
@@ -112,5 +112,5 @@ module.exports = function (tags, pbfFile, outputFile, callback) {
   handlerB.end()
   handlerC.end()
   wstream.end()
-  callback()
+  wstream.on('close', callback)
 }

--- a/src/validators/redundantTROneway/index.js
+++ b/src/validators/redundantTROneway/index.js
@@ -184,5 +184,5 @@ module.exports = function (tags, pbfFile, outputFile, callback) {
   handlerB.end()
   handlerC.end()
   wstream.end()
-  callback()
+  wstream.on('close', callback)
 }


### PR DESCRIPTION
The tests were failing locally and inconsistently because the callback event for the stream was being called before the linter file output was finished writing. This pull request changes the linters so they wait for the stream end event before calling the callback.

🤗 