### PR TITLE
Restructured output feature-collection format

### DIFF
--- a/src/validators/excessiveRolesTR/index.js
+++ b/src/validators/excessiveRolesTR/index.js
@@ -1,129 +1,131 @@
-'use strict'
-var fs = require('fs')
-var osmium = require('osmium')
-var turf = require('@turf/turf')
-var _ = require('underscore')
-var util = require('../../util')
+"use strict";
+var fs = require("fs");
+var osmium = require("osmium");
+var turf = require("@turf/turf");
+var _ = require("underscore");
+var util = require("../../util");
 
-module.exports = function (tags, pbfFile, outputFile, callback) {
-  var wstream = fs.createWriteStream(outputFile)
-  var relationMembers = {}
-  var nodes = {}
-  var ways = {}
-  var relations = {}
-  var osmlint = 'excessiverolestr'
-  var handlerA = new osmium.Handler()
-  handlerA.on('relation', function (relation) {
-    if (relation.tags('type') === 'restriction') {
-      var tr = {}
-      var flagTR = false
-      var members = relation.members()
+module.exports = function(tags, pbfFile, outputFile, callback) {
+  var wstream = fs.createWriteStream(outputFile);
+  var relationMembers = {};
+  var nodes = {};
+  var ways = {};
+  var relations = {};
+  var osmlint = "excessiverolestr";
+  var handlerA = new osmium.Handler();
+  handlerA.on("relation", function(relation) {
+    // This handler collects all metadata of a relation
+    if (relation.tags("type") === "restriction") {
+      var tr = {};
+      var flagTR = false;
+      var members = relation.members();
       for (var d = 0; d < members.length; d++) {
         if (tr[members[d].role]) {
-          tr[members[d].role].push(members[d])
-          // It is good to have more than one `via`-way but not `from` or `to`.
-          if (!(members[d].role === 'via' && members[d].type === 'w')) {
-            flagTR = true
+          tr[members[d].role].push(members[d]);
+          if (!(members[d].role === "via" && members[d].type === "w")) {
+            flagTR = true;
           }
         } else {
-          tr[members[d].role] = [members[d]]
+          tr[members[d].role] = [members[d]];
         }
       }
-
       if (flagTR) {
-        var relationFeature = util.relationFeature(relation)
-        relations[relation.id] = relationFeature
+        var relationFeature = util.relationFeature(relation);
+        relations[relation.id] = relationFeature;
         for (var i = 0; i < members.length; i++) {
-          var member = members[i]
-          member.idrel = relation.id
+          var member = members[i];
+          member.idrel = relation.id;
 
           // Check nodes
-          if (member.type === 'n') {
+          if (member.type === "n") {
             if (nodes[member.ref]) {
-              nodes[member.ref].push(member)
+              nodes[member.ref].push(member);
             } else {
-              nodes[member.ref] = [member]
+              nodes[member.ref] = [member];
             }
           }
           // Check ways
-          if (member.type === 'w') {
+          if (member.type === "w") {
             if (ways[member.ref]) {
-              ways[member.ref].push(member)
+              ways[member.ref].push(member);
             } else {
-              ways[member.ref] = [member]
+              ways[member.ref] = [member];
             }
           }
         }
       }
     }
-  })
-  var reader = new osmium.BasicReader(pbfFile)
-  osmium.apply(reader, handlerA)
+  });
+  var reader = new osmium.BasicReader(pbfFile);
+  osmium.apply(reader, handlerA);
 
-  var handlerB = new osmium.Handler()
-  handlerB.on('node', function (node) {
+  var handlerB = new osmium.Handler();
+  handlerB.on("node", function(node) {
     if (nodes[node.id]) {
       // one node can belong to many relations
-      var nodeRols = nodes[node.id]
-      for (var n = 0; n < nodeRols.length; n++) {
-        var nodeRel = nodeRols[n]
-        var nodeFeature = util.mergeNodeRelationFeature(node, relations[nodeRel.idrel], nodeRel)
-        if (relationMembers[nodeFeature.properties['@idrel']]) {
-          relationMembers[nodeFeature.properties['@idrel']].push(nodeFeature)
+      var nodeRoles = nodes[node.id];
+      for (var n = 0; n < nodeRoles.length; n++) {
+        var nodeRel = nodeRoles[n];
+        var nodeFeature = util.mergeNodeRelationFeature(
+          node,
+          relations[nodeRel.idrel],
+          nodeRel
+        );
+        if (relationMembers[nodeFeature.properties["@idrel"]]) {
+          relationMembers[nodeFeature.properties["@idrel"]].push(nodeFeature);
         } else {
-          relationMembers[nodeFeature.properties['@idrel']] = [nodeFeature]
+          relationMembers[nodeFeature.properties["@idrel"]] = [nodeFeature];
         }
       }
     }
-  })
+  });
 
-  reader = new osmium.Reader(pbfFile)
-  osmium.apply(reader, handlerB)
+  reader = new osmium.Reader(pbfFile);
+  osmium.apply(reader, handlerB);
 
-  var handlerC = new osmium.Handler()
-  handlerC.on('way', function (way) {
+  var handlerC = new osmium.Handler();
+  handlerC.on("way", function(way) {
     if (ways[way.id]) {
       // one way can belong to many relations
-      var wayRols = ways[way.id]
-      for (var m = 0; m < wayRols.length; m++) {
-        var wayRol = wayRols[m]
-        var wayFeature = util.mergeWayRelationFeature(way, relations[wayRol.idrel], wayRol)
-        if (relationMembers[wayFeature.properties['@idrel']]) {
-          relationMembers[wayFeature.properties['@idrel']].push(wayFeature)
+      var wayRoles = ways[way.id];
+      for (var m = 0; m < wayRoles.length; m++) {
+        var wayRel = wayRoles[m];
+        var wayFeature = util.mergeWayRelationFeature(
+          way,
+          relations[wayRel.idrel],
+          wayRel
+        );
+        if (relationMembers[wayFeature.properties["@idrel"]]) {
+          relationMembers[wayFeature.properties["@idrel"]].push(wayFeature);
         } else {
-          relationMembers[wayFeature.properties['@idrel']] = [wayFeature]
+          relationMembers[wayFeature.properties["@idrel"]] = [wayFeature];
         }
       }
     }
-  })
+  });
 
-  reader = new osmium.Reader(pbfFile)
-  var locationHandler = new osmium.LocationHandler()
-  osmium.apply(reader, locationHandler, handlerC)
+  reader = new osmium.Reader(pbfFile);
+  var locationHandler = new osmium.LocationHandler();
+  osmium.apply(reader, locationHandler, handlerC);
 
-  handlerC.on('done', function () {
+  handlerC.on("done", function() {
     for (var rel in relationMembers) {
       if (relationMembers[rel].length > 0) {
         var fc = {
-          type: 'FeatureCollection',
+          type: "FeatureCollection",
           features: relationMembers[rel]
-        }
-        var line = turf.polygonToLineString(turf.bboxPolygon(turf.bbox(fc)))
-        line.properties = _.extend(relations[rel].props, {
-          members: relations[rel].members
-        }, relations[rel].tags, {
-          relations: relationMembers[rel]
-        }, {
+        };
+        fc.name = _.extend({
           _osmlint: osmlint
-        })
-        wstream.write(JSON.stringify(line) + '\n')
+        });
+        wstream.write(JSON.stringify(fc) + "\n");
       }
     }
-  })
+  });
 
-  handlerA.end()
-  handlerB.end()
-  handlerC.end()
-  wstream.end()
-  wstream.on('close', callback)
-}
+  handlerA.end();
+  handlerB.end();
+  handlerC.end();
+  wstream.end();
+  wstream.on("close", callback);
+};

--- a/src/validators/invalidRoleTR/README.md
+++ b/src/validators/invalidRoleTR/README.md
@@ -4,4 +4,4 @@ Detect turn-restriction that has invalid roles
 
 ### usage
 
-`osmlinto invalidrole california-latest.osm.pbf output.json`
+`osmlinto invalidroletr california-latest.osm.pbf output.json`

--- a/src/validators/invalidRoleTR/index.js
+++ b/src/validators/invalidRoleTR/index.js
@@ -1,127 +1,130 @@
-'use strict'
-var fs = require('fs')
-var osmium = require('osmium')
-var turf = require('@turf/turf')
-var _ = require('underscore')
-var util = require('../../util')
+"use strict";
+var fs = require("fs");
+var osmium = require("osmium");
+var turf = require("@turf/turf");
+var _ = require("underscore");
+var util = require("../../util");
 
-module.exports = function (tags, pbfFile, outputFile, callback) {
-  var wstream = fs.createWriteStream(outputFile)
-  var relationMembers = {}
-  var nodes = {}
-  var ways = {}
-  var relations = {}
-  var roles = ['from', 'via', 'to']
-  var osmlint = 'invalidroletr'
+module.exports = function(tags, pbfFile, outputFile, callback) {
+  var wstream = fs.createWriteStream(outputFile);
+  var relationMembers = {};
+  var nodes = {};
+  var ways = {};
+  var relations = {};
+  var roles = ["from", "via", "to"];
+  var osmlint = "invalidroletr";
 
-  var handlerA = new osmium.Handler()
-  handlerA.on('relation', function (relation) {
-    if (relation.tags('type') === 'restriction') {
-      var tr = {}
-      var flagTR = false
-      var members = relation.members()
+  var handlerA = new osmium.Handler();
+  handlerA.on("relation", function(relation) {
+    if (relation.tags("type") === "restriction") {
+      var tr = {};
+      var flagTR = false;
+      var members = relation.members();
       for (var d = 0; d < members.length; d++) {
         if (!members[d].role || roles.indexOf(members[d].role) < 0) {
-          flagTR = true
+          flagTR = true;
         }
-        tr[members[d].ref] = members[d]
+        tr[members[d].ref] = members[d];
       }
 
       if (flagTR) {
-        var relationFeature = util.relationFeature(relation)
-        relations[relation.id] = relationFeature
+        var relationFeature = util.relationFeature(relation);
+        relations[relation.id] = relationFeature;
         for (var i = 0; i < members.length; i++) {
-          var member = members[i]
-          member.idrel = relation.id
+          var member = members[i];
+          member.idrel = relation.id;
 
           // Check nodes
-          if (member.type === 'n') {
+          if (member.type === "n") {
             if (nodes[member.ref]) {
-              nodes[member.ref].push(member)
+              nodes[member.ref].push(member);
             } else {
-              nodes[member.ref] = [member]
+              nodes[member.ref] = [member];
             }
           }
           // Check ways
-          if (member.type === 'w') {
+          if (member.type === "w") {
             if (ways[member.ref]) {
-              ways[member.ref].push(member)
+              ways[member.ref].push(member);
             } else {
-              ways[member.ref] = [member]
+              ways[member.ref] = [member];
             }
           }
         }
       }
     }
-  })
+  });
 
-  var reader = new osmium.BasicReader(pbfFile)
-  osmium.apply(reader, handlerA)
+  var reader = new osmium.BasicReader(pbfFile);
+  osmium.apply(reader, handlerA);
 
-  var handlerB = new osmium.Handler()
-  handlerB.on('node', function (node) {
+  var handlerB = new osmium.Handler();
+  handlerB.on("node", function(node) {
     if (nodes[node.id]) {
       // one node can belong to many relations
-      var nodeRols = nodes[node.id]
-      for (var n = 0; n < nodeRols.length; n++) {
-        var nodeRel = nodeRols[n]
-        var nodeFeature = util.mergeNodeRelationFeature(node, relations[nodeRel.idrel], nodeRel)
-        if (relationMembers[nodeFeature.properties['@idrel']]) {
-          relationMembers[nodeFeature.properties['@idrel']].push(nodeFeature)
+      var nodeRoles = nodes[node.id];
+      for (var n = 0; n < nodeRoles.length; n++) {
+        var nodeRole = nodeRoles[n];
+        var nodeFeature = util.mergeNodeRelationFeature(
+          node,
+          relations[nodeRole.idrel],
+          nodeRole
+        );
+        if (relationMembers[nodeFeature.properties["@idrel"]]) {
+          relationMembers[nodeFeature.properties["@idrel"]].push(nodeFeature);
         } else {
-          relationMembers[nodeFeature.properties['@idrel']] = [nodeFeature]
+          relationMembers[nodeFeature.properties["@idrel"]] = [nodeFeature];
         }
       }
     }
-  })
+  });
 
-  reader = new osmium.Reader(pbfFile)
-  osmium.apply(reader, handlerB)
+  reader = new osmium.Reader(pbfFile);
+  osmium.apply(reader, handlerB);
 
-  var handlerC = new osmium.Handler()
-  handlerC.on('way', function (way) {
+  var handlerC = new osmium.Handler();
+  handlerC.on("way", function(way) {
     if (ways[way.id]) {
       // one way can belong to many relations
-      var wayRols = ways[way.id]
-      for (var m = 0; m < wayRols.length; m++) {
-        var wayRol = wayRols[m]
-        var wayFeature = util.mergeWayRelationFeature(way, relations[wayRol.idrel], wayRol)
-        if (relationMembers[wayFeature.properties['@idrel']]) {
-          relationMembers[wayFeature.properties['@idrel']].push(wayFeature)
+      var wayRoles = ways[way.id];
+      for (var m = 0; m < wayRoles.length; m++) {
+        var wayRole = wayRoles[m];
+        var wayFeature = util.mergeWayRelationFeature(
+          way,
+          relations[wayRole.idrel],
+          wayRole
+        );
+        if (relationMembers[wayFeature.properties["@idrel"]]) {
+          relationMembers[wayFeature.properties["@idrel"]].push(wayFeature);
         } else {
-          relationMembers[wayFeature.properties['@idrel']] = [wayFeature]
+          relationMembers[wayFeature.properties["@idrel"]] = [wayFeature];
         }
       }
     }
-  })
+  });
 
-  reader = new osmium.Reader(pbfFile)
-  var locationHandler = new osmium.LocationHandler()
-  osmium.apply(reader, locationHandler, handlerC)
+  reader = new osmium.Reader(pbfFile);
+  var locationHandler = new osmium.LocationHandler();
+  osmium.apply(reader, locationHandler, handlerC);
 
-  handlerC.on('done', function () {
+  handlerC.on("done", function() {
     for (var rel in relationMembers) {
       if (relationMembers[rel].length > 0) {
         var fc = {
-          type: 'FeatureCollection',
+          type: "FeatureCollection",
           features: relationMembers[rel]
-        }
-        var line = turf.polygonToLineString(turf.bboxPolygon(turf.bbox(fc)))
-        line.properties = _.extend(relations[rel].props, {
-          members: relations[rel].members
-        }, relations[rel].tags, {
-          relations: relationMembers[rel]
-        }, {
+        };
+        fc.name = _.extend({
           _osmlint: osmlint
-        })
-        wstream.write(JSON.stringify(line) + '\n')
+        });
+        wstream.write(JSON.stringify(fc) + "\n");
       }
     }
-  })
+  });
 
-  handlerA.end()
-  handlerB.end()
-  handlerC.end()
-  wstream.end()
-  wstream.on('close', callback)
-}
+  handlerA.end();
+  handlerB.end();
+  handlerC.end();
+  wstream.end();
+  wstream.on("close", callback);
+};

--- a/src/validators/missingRoleTR/index.js
+++ b/src/validators/missingRoleTR/index.js
@@ -1,126 +1,129 @@
-'use strict'
-var fs = require('fs')
-var osmium = require('osmium')
-var _ = require('underscore')
-var turf = require('@turf/turf')
-var util = require('../../util')
+"use strict";
+var fs = require("fs");
+var osmium = require("osmium");
+var _ = require("underscore");
+var turf = require("@turf/turf");
+var util = require("../../util");
 
-module.exports = function (tags, pbfFile, outputFile, callback) {
-  var wstream = fs.createWriteStream(outputFile)
-  var relationMembers = {}
-  var nodes = {}
-  var ways = {}
-  var relations = {}
-  var osmlint = 'missingroletr'
+module.exports = function(tags, pbfFile, outputFile, callback) {
+  var wstream = fs.createWriteStream(outputFile);
+  var relationMembers = {};
+  var nodes = {};
+  var ways = {};
+  var relations = {};
+  var osmlint = "missingroletr";
 
-  var handlerA = new osmium.Handler()
-  handlerA.on('relation', function (relation) {
-    if (relation.tags('type') === 'restriction') {
+  var handlerA = new osmium.Handler();
+  handlerA.on("relation", function(relation) {
+    if (relation.tags("type") === "restriction") {
       var tr = {
         from: false,
         to: false,
         via: false
-      }
-      var members = relation.members()
+      };
+      var members = relation.members();
       for (var d = 0; d < members.length; d++) {
-        tr[members[d].role] = members[d]
+        tr[members[d].role] = members[d];
       }
-      var elems = _.without(_.values(tr), false)
+      var elems = _.without(_.values(tr), false);
       if (elems.length < 3) {
-        var relationFeature = util.relationFeature(relation)
-        relations[relation.id] = relationFeature
+        var relationFeature = util.relationFeature(relation);
+        relations[relation.id] = relationFeature;
         for (var i = 0; i < members.length; i++) {
-          var member = members[i]
-          member.idrel = relation.id
+          var member = members[i];
+          member.idrel = relation.id;
 
           // Check nodes
-          if (member.type === 'n') {
+          if (member.type === "n") {
             if (nodes[member.ref]) {
-              nodes[member.ref].push(member)
+              nodes[member.ref].push(member);
             } else {
-              nodes[member.ref] = [member]
+              nodes[member.ref] = [member];
             }
           }
           // Check ways
-          if (member.type === 'w') {
+          if (member.type === "w") {
             if (ways[member.ref]) {
-              ways[member.ref].push(member)
+              ways[member.ref].push(member);
             } else {
-              ways[member.ref] = [member]
+              ways[member.ref] = [member];
             }
           }
         }
       }
     }
-  })
+  });
 
-  var reader = new osmium.BasicReader(pbfFile)
-  osmium.apply(reader, handlerA)
+  var reader = new osmium.BasicReader(pbfFile);
+  osmium.apply(reader, handlerA);
 
-  var handlerB = new osmium.Handler()
-  handlerB.on('node', function (node) {
+  var handlerB = new osmium.Handler();
+  handlerB.on("node", function(node) {
     if (nodes[node.id]) {
       // one node can belong to many relations
-      var nodeRols = nodes[node.id]
+      var nodeRols = nodes[node.id];
       for (var n = 0; n < nodeRols.length; n++) {
-        var nodeRel = nodeRols[n]
-        var nodeFeature = util.mergeNodeRelationFeature(node, relations[nodeRel.idrel], nodeRel)
-        if (relationMembers[nodeFeature.properties['@idrel']]) {
-          relationMembers[nodeFeature.properties['@idrel']].push(nodeFeature)
+        var nodeRel = nodeRols[n];
+        var nodeFeature = util.mergeNodeRelationFeature(
+          node,
+          relations[nodeRel.idrel],
+          nodeRel
+        );
+        if (relationMembers[nodeFeature.properties["@idrel"]]) {
+          relationMembers[nodeFeature.properties["@idrel"]].push(nodeFeature);
         } else {
-          relationMembers[nodeFeature.properties['@idrel']] = [nodeFeature]
+          relationMembers[nodeFeature.properties["@idrel"]] = [nodeFeature];
         }
       }
     }
-  })
+  });
 
-  reader = new osmium.Reader(pbfFile)
-  osmium.apply(reader, handlerB)
+  reader = new osmium.Reader(pbfFile);
+  osmium.apply(reader, handlerB);
 
-  var handlerC = new osmium.Handler()
-  handlerC.on('way', function (way) {
+  var handlerC = new osmium.Handler();
+  handlerC.on("way", function(way) {
     if (ways[way.id]) {
       // one way can belong to many relations
-      var wayRols = ways[way.id]
+      var wayRols = ways[way.id];
       for (var m = 0; m < wayRols.length; m++) {
-        var wayRol = wayRols[m]
-        var wayFeature = util.mergeWayRelationFeature(way, relations[wayRol.idrel], wayRol)
-        if (relationMembers[wayFeature.properties['@idrel']]) {
-          relationMembers[wayFeature.properties['@idrel']].push(wayFeature)
+        var wayRol = wayRols[m];
+        var wayFeature = util.mergeWayRelationFeature(
+          way,
+          relations[wayRol.idrel],
+          wayRol
+        );
+        if (relationMembers[wayFeature.properties["@idrel"]]) {
+          relationMembers[wayFeature.properties["@idrel"]].push(wayFeature);
         } else {
-          relationMembers[wayFeature.properties['@idrel']] = [wayFeature]
+          relationMembers[wayFeature.properties["@idrel"]] = [wayFeature];
         }
       }
     }
-  })
+  });
 
-  reader = new osmium.Reader(pbfFile)
-  var locationHandler = new osmium.LocationHandler()
-  osmium.apply(reader, locationHandler, handlerC)
+  reader = new osmium.Reader(pbfFile);
+  var locationHandler = new osmium.LocationHandler();
+  osmium.apply(reader, locationHandler, handlerC);
 
-  handlerC.on('done', function () {
+  handlerC.on("done", function() {
     for (var rel in relationMembers) {
       if (relationMembers[rel].length > 0) {
         var fc = {
-          type: 'FeatureCollection',
+          type: "FeatureCollection",
           features: relationMembers[rel]
-        }
-        var line = turf.polygonToLineString(turf.bboxPolygon(turf.bbox(fc)))
-        line.properties = _.extend(relations[rel].props, {
-          members: relations[rel].members
-        }, relations[rel].tags, {
-          relations: relationMembers[rel]
-        }, {
+        };
+        fc.name = _.extend({
           _osmlint: osmlint
-        })
-        wstream.write(JSON.stringify(line) + '\n')
+        });
+        wstream.write(JSON.stringify(fc) + "\n");
       }
     }
-  })
+  });
 
-  handlerA.end()
-  handlerB.end()
-  handlerC.end()
-  wstream.end()
-  wstream.on('close', callback)
-}
+  handlerA.end();
+  handlerB.end();
+  handlerC.end();
+  wstream.end();
+  wstream.on("close", callback);
+};

--- a/src/validators/missingTypeRestrictionTR/index.js
+++ b/src/validators/missingTypeRestrictionTR/index.js
@@ -1,116 +1,125 @@
-'use strict'
-var fs = require('fs')
-var osmium = require('osmium')
-var _ = require('underscore')
-var turf = require('@turf/turf')
-var util = require('../../util')
+"use strict";
+var fs = require("fs");
+var osmium = require("osmium");
+var _ = require("underscore");
+var turf = require("@turf/turf");
+var util = require("../../util");
 
-module.exports = function (tags, pbfFile, outputFile, callback) {
-  var wstream = fs.createWriteStream(outputFile)
-  var relationMembers = {}
-  var nodes = {}
-  var ways = {}
-  var relations = {}
-  var osmlint = 'missingtyperestrictiontr'
+module.exports = function(tags, pbfFile, outputFile, callback) {
+  var wstream = fs.createWriteStream(outputFile);
+  var relationMembers = {};
+  var nodes = {};
+  var ways = {};
+  var relations = {};
+  var osmlint = "missingtyperestrictiontr";
 
-  var handlerA = new osmium.Handler()
-  handlerA.on('relation', function (relation) {
-    var tags = relation.tags()
-    if ((tags.type === 'restriction' && (!tags.restriction && !tags['restriction:conditional'] && !tags['restriction:foot'])) ||
-      ((tags.restriction || tags['restriction:conditional']) && tags.type !== 'restriction')) {
-      var members = relation.members()
-      var relationFeature = util.relationFeature(relation)
-      relations[relation.id] = relationFeature
+  var handlerA = new osmium.Handler();
+  handlerA.on("relation", function(relation) {
+    var tags = relation.tags();
+    if (
+      (tags.type === "restriction" &&
+        (!tags.restriction &&
+          !tags["restriction:conditional"] &&
+          !tags["restriction:foot"])) ||
+      ((tags.restriction || tags["restriction:conditional"]) &&
+        tags.type !== "restriction")
+    ) {
+      var members = relation.members();
+      var relationFeature = util.relationFeature(relation);
+      relations[relation.id] = relationFeature;
       for (var i = 0; i < members.length; i++) {
-        var member = members[i]
-        member.idrel = relation.id
+        var member = members[i];
+        member.idrel = relation.id;
         // Check nodes
-        if (member.type === 'n') {
+        if (member.type === "n") {
           if (nodes[member.ref]) {
-            nodes[member.ref].push(member)
+            nodes[member.ref].push(member);
           } else {
-            nodes[member.ref] = [member]
+            nodes[member.ref] = [member];
           }
         }
         // Check ways
-        if (member.type === 'w') {
+        if (member.type === "w") {
           if (ways[member.ref]) {
-            ways[member.ref].push(member)
+            ways[member.ref].push(member);
           } else {
-            ways[member.ref] = [member]
+            ways[member.ref] = [member];
           }
         }
       }
     }
-  })
+  });
 
-  var reader = new osmium.BasicReader(pbfFile)
-  osmium.apply(reader, handlerA)
+  var reader = new osmium.BasicReader(pbfFile);
+  osmium.apply(reader, handlerA);
 
-  var handlerB = new osmium.Handler()
-  handlerB.on('node', function (node) {
+  var handlerB = new osmium.Handler();
+  handlerB.on("node", function(node) {
     if (nodes[node.id]) {
       // one node can belong to many relations
-      var nodeRols = nodes[node.id]
+      var nodeRols = nodes[node.id];
       for (var n = 0; n < nodeRols.length; n++) {
-        var nodeRel = nodeRols[n]
-        var nodeFeature = util.mergeNodeRelationFeature(node, relations[nodeRel.idrel], nodeRel)
-        if (relationMembers[nodeFeature.properties['@idrel']]) {
-          relationMembers[nodeFeature.properties['@idrel']].push(nodeFeature)
+        var nodeRel = nodeRols[n];
+        var nodeFeature = util.mergeNodeRelationFeature(
+          node,
+          relations[nodeRel.idrel],
+          nodeRel
+        );
+        if (relationMembers[nodeFeature.properties["@idrel"]]) {
+          relationMembers[nodeFeature.properties["@idrel"]].push(nodeFeature);
         } else {
-          relationMembers[nodeFeature.properties['@idrel']] = [nodeFeature]
+          relationMembers[nodeFeature.properties["@idrel"]] = [nodeFeature];
         }
       }
     }
-  })
+  });
 
-  reader = new osmium.Reader(pbfFile)
-  osmium.apply(reader, handlerB)
+  reader = new osmium.Reader(pbfFile);
+  osmium.apply(reader, handlerB);
 
-  var handlerC = new osmium.Handler()
-  handlerC.on('way', function (way) {
+  var handlerC = new osmium.Handler();
+  handlerC.on("way", function(way) {
     if (ways[way.id]) {
       // one way can belong to many relations
-      var wayRols = ways[way.id]
+      var wayRols = ways[way.id];
       for (var m = 0; m < wayRols.length; m++) {
-        var wayRol = wayRols[m]
-        var wayFeature = util.mergeWayRelationFeature(way, relations[wayRol.idrel], wayRol)
-        if (relationMembers[wayFeature.properties['@idrel']]) {
-          relationMembers[wayFeature.properties['@idrel']].push(wayFeature)
+        var wayRol = wayRols[m];
+        var wayFeature = util.mergeWayRelationFeature(
+          way,
+          relations[wayRol.idrel],
+          wayRol
+        );
+        if (relationMembers[wayFeature.properties["@idrel"]]) {
+          relationMembers[wayFeature.properties["@idrel"]].push(wayFeature);
         } else {
-          relationMembers[wayFeature.properties['@idrel']] = [wayFeature]
+          relationMembers[wayFeature.properties["@idrel"]] = [wayFeature];
         }
       }
     }
-  })
+  });
 
-  reader = new osmium.Reader(pbfFile)
-  var locationHandler = new osmium.LocationHandler()
-  osmium.apply(reader, locationHandler, handlerC)
+  reader = new osmium.Reader(pbfFile);
+  var locationHandler = new osmium.LocationHandler();
+  osmium.apply(reader, locationHandler, handlerC);
 
-  handlerC.on('done', function () {
+  handlerC.on("done", function() {
     for (var rel in relationMembers) {
       if (relationMembers[rel].length > 0) {
         var fc = {
-          type: 'FeatureCollection',
+          type: "FeatureCollection",
           features: relationMembers[rel]
-        }
-        var line = turf.polygonToLineString(turf.bboxPolygon(turf.bbox(fc)))
-        line.properties = _.extend(relations[rel].props, {
-          members: relations[rel].members
-        }, relations[rel].tags, {
-          relations: relationMembers[rel]
-        }, {
+        };
+        fc.name = _.extend({
           _osmlint: osmlint
-        })
-        wstream.write(JSON.stringify(line) + '\n')
+        });
+        wstream.write(JSON.stringify(fc) + "\n");
       }
     }
-  })
+  });
 
-  handlerA.end()
-  handlerB.end()
-  handlerC.end()
-  wstream.end()
-  wstream.on('close', callback)
-}
+  handlerA.end();
+  handlerB.end();
+  handlerC.end();
+  wstream.end();
+  wstream.on("close", callback);
+};

--- a/src/validators/redundantTROneway/README.md
+++ b/src/validators/redundantTROneway/README.md
@@ -4,4 +4,4 @@ Detect redundant TR's in oneway roads
 
 ### usage
 
-`osmlinto missingtyperestrictiontr california-latest.osm.pbf output.json`
+`osmlinto redundanttroneway california-latest.osm.pbf output.json`

--- a/src/validators/redundantTROneway/index.js
+++ b/src/validators/redundantTROneway/index.js
@@ -1,188 +1,219 @@
-'use strict'
-var fs = require('fs')
-var osmium = require('osmium')
-var _ = require('underscore')
-var turf = require('@turf/turf')
-var util = require('../../util')
+"use strict";
+var fs = require("fs");
+var osmium = require("osmium");
+var _ = require("underscore");
+var turf = require("@turf/turf");
+var util = require("../../util");
 
-module.exports = function (tags, pbfFile, outputFile, callback) {
-  var wstream = fs.createWriteStream(outputFile)
-  var relationMembers = {}
-  var nodes = {}
-  var ways = {}
-  var relations = {}
-  var osmlint = 'redundanttroneway'
+module.exports = function(tags, pbfFile, outputFile, callback) {
+  var wstream = fs.createWriteStream(outputFile);
+  var relationMembers = {};
+  var nodes = {};
+  var ways = {};
+  var relations = {};
+  var osmlint = "redundanttroneway";
 
-  var handlerA = new osmium.Handler()
-  handlerA.on('relation', function (relation) {
-    var tags = relation.tags()
-    if (tags.type === 'restriction' &&
+  var handlerA = new osmium.Handler();
+  handlerA.on("relation", function(relation) {
+    var tags = relation.tags();
+    if (
+      tags.type === "restriction" &&
       ((tags.restriction &&
-          (tags.restriction === 'no_left_turn' ||
-            tags.restriction === 'no_right_turn' ||
-            tags.restriction === 'no_u_turn')) ||
-        (tags['restriction:conditional'] &&
-          (tags['restriction:conditional'].indexOf('no_left_turn') > -1 || tags['restriction:conditional'].indexOf('no_right_turn') > -1 || tags['restriction:conditional'].indexOf('no_u_turn') > -1)))) {
-      var members = relation.members()
-      var relationFeature = util.relationFeature(relation)
-      relations[relation.id] = relationFeature
+        (tags.restriction === "no_left_turn" ||
+          tags.restriction === "no_right_turn" ||
+          tags.restriction === "no_u_turn")) ||
+        (tags["restriction:conditional"] &&
+          (tags["restriction:conditional"].indexOf("no_left_turn") > -1 ||
+            tags["restriction:conditional"].indexOf("no_right_turn") > -1 ||
+            tags["restriction:conditional"].indexOf("no_u_turn") > -1)))
+    ) {
+      var members = relation.members();
+      var relationFeature = util.relationFeature(relation);
+      relations[relation.id] = relationFeature;
       for (var i = 0; i < members.length; i++) {
-        var member = members[i]
-        member.idrel = relation.id
+        var member = members[i];
+        member.idrel = relation.id;
         // Check nodes
-        if (member.type === 'n') {
+        if (member.type === "n") {
           if (nodes[member.ref]) {
-            nodes[member.ref].push(member)
+            nodes[member.ref].push(member);
           } else {
-            nodes[member.ref] = [member]
+            nodes[member.ref] = [member];
           }
         }
         // Check ways
-        if (member.type === 'w') {
+        if (member.type === "w") {
           if (ways[member.ref]) {
-            ways[member.ref].push(member)
+            ways[member.ref].push(member);
           } else {
-            ways[member.ref] = [member]
+            ways[member.ref] = [member];
           }
         }
       }
     }
-  })
+  });
 
-  var reader = new osmium.BasicReader(pbfFile)
-  osmium.apply(reader, handlerA)
+  var reader = new osmium.BasicReader(pbfFile);
+  osmium.apply(reader, handlerA);
 
-  var handlerB = new osmium.Handler()
-  handlerB.on('node', function (node) {
+  var handlerB = new osmium.Handler();
+  handlerB.on("node", function(node) {
     if (nodes[node.id]) {
       // one node can belong to many relations
-      var nodeRols = nodes[node.id]
+      var nodeRols = nodes[node.id];
       for (var n = 0; n < nodeRols.length; n++) {
-        var nodeRel = nodeRols[n]
-        var nodeFeature = util.mergeNodeRelationFeature(node, relations[nodeRel.idrel], nodeRel)
-        if (relationMembers[nodeFeature.properties['@idrel']]) {
-          relationMembers[nodeFeature.properties['@idrel']].push(nodeFeature)
+        var nodeRel = nodeRols[n];
+        var nodeFeature = util.mergeNodeRelationFeature(
+          node,
+          relations[nodeRel.idrel],
+          nodeRel
+        );
+        if (relationMembers[nodeFeature.properties["@idrel"]]) {
+          relationMembers[nodeFeature.properties["@idrel"]].push(nodeFeature);
         } else {
-          relationMembers[nodeFeature.properties['@idrel']] = [nodeFeature]
+          relationMembers[nodeFeature.properties["@idrel"]] = [nodeFeature];
         }
       }
     }
-  })
+  });
 
-  reader = new osmium.Reader(pbfFile)
-  osmium.apply(reader, handlerB)
+  reader = new osmium.Reader(pbfFile);
+  osmium.apply(reader, handlerB);
 
-  var handlerC = new osmium.Handler()
-  handlerC.on('way', function (way) {
+  var handlerC = new osmium.Handler();
+  handlerC.on("way", function(way) {
     if (ways[way.id]) {
       // one way can belong to many relations
-      var wayRols = ways[way.id]
+      var wayRols = ways[way.id];
       for (var m = 0; m < wayRols.length; m++) {
-        var wayRol = wayRols[m]
-        var wayFeature = util.mergeWayRelationFeature(way, relations[wayRol.idrel], wayRol)
-        if (relationMembers[wayFeature.properties['@idrel']]) {
-          relationMembers[wayFeature.properties['@idrel']].push(wayFeature)
+        var wayRol = wayRols[m];
+        var wayFeature = util.mergeWayRelationFeature(
+          way,
+          relations[wayRol.idrel],
+          wayRol
+        );
+        if (relationMembers[wayFeature.properties["@idrel"]]) {
+          relationMembers[wayFeature.properties["@idrel"]].push(wayFeature);
         } else {
-          relationMembers[wayFeature.properties['@idrel']] = [wayFeature]
+          relationMembers[wayFeature.properties["@idrel"]] = [wayFeature];
         }
       }
     }
-  })
+  });
 
-  reader = new osmium.Reader(pbfFile)
-  var locationHandler = new osmium.LocationHandler()
-  osmium.apply(reader, locationHandler, handlerC)
+  reader = new osmium.Reader(pbfFile);
+  var locationHandler = new osmium.LocationHandler();
+  osmium.apply(reader, locationHandler, handlerC);
 
-  handlerC.on('done', function () {
+  handlerC.on("done", function() {
     for (var rel in relationMembers) {
       if (relationMembers[rel].length > 0) {
-        var relTags = relations[rel].tags
-        var rMenbers = util.sortRoles(relationMembers[rel])
-        var from = rMenbers.from[0]
-        var via = rMenbers.via[0]
-        var to = rMenbers.to[0]
-        var simFrom = util.simpleRole(rMenbers.from)
-        var simVia = util.simpleRole(rMenbers.via)
-        var simTo = util.simpleRole(rMenbers.to)
-        var flag = false
+        var relTags = relations[rel].tags;
+        var rMenbers = util.sortRoles(relationMembers[rel]);
+        var from = rMenbers.from[0];
+        var via = rMenbers.via[0];
+        var to = rMenbers.to[0];
+        var simFrom = util.simpleRole(rMenbers.from);
+        var simVia = util.simpleRole(rMenbers.via);
+        var simTo = util.simpleRole(rMenbers.to);
+        var flag = false;
 
         if (from && via && to) {
-          var restriction = (
-            relTags.restriction === 'no_left_turn' ||
-            (relTags['restriction:conditional'] && relTags['restriction:conditional'].indexOf('no_left_turn') > -1) ||
-            relTags.restriction === 'no_right_turn' ||
-            (relTags['restriction:conditional'] && relTags['restriction:conditional'].indexOf('no_right_turn') > -1)
-          )
+          var restriction =
+            relTags.restriction === "no_left_turn" ||
+            (relTags["restriction:conditional"] &&
+              relTags["restriction:conditional"].indexOf("no_left_turn") >
+                -1) ||
+            relTags.restriction === "no_right_turn" ||
+            (relTags["restriction:conditional"] &&
+              relTags["restriction:conditional"].indexOf("no_right_turn") > -1);
 
           // Case1: When the "to" roles has oneway  and the ending coordinate  is equal  to via
-          if (restriction &&
-            simVia.type === 'node' &&
+          if (
+            restriction &&
+            simVia.type === "node" &&
             _.intersection(simTo.end, simVia.start).length === 2 &&
             to.properties.oneway &&
-            (to.properties.oneway === 'yes' || to.properties.oneway === '1')) {
-            flag = true
+            (to.properties.oneway === "yes" || to.properties.oneway === "1")
+          ) {
+            flag = true;
           }
           // Case2: When the "to" roles has oneway  and the start coordinate  is equal to via
-          if (restriction &&
-            simVia.type === 'node' &&
+          if (
+            restriction &&
+            simVia.type === "node" &&
             _.intersection(simTo.start, simVia.start).length === 2 &&
-            (to.properties.oneway &&
-              to.properties.oneway === '-1')) {
-            flag = true
+            (to.properties.oneway && to.properties.oneway === "-1")
+          ) {
+            flag = true;
           }
 
-          restriction = (
-            relTags.restriction === 'no_u_turn' ||
-            (relTags['restriction:conditional'] && relTags['restriction:conditional'].indexOf('no_u_turn') > -1)
-          )
+          restriction =
+            relTags.restriction === "no_u_turn" ||
+            (relTags["restriction:conditional"] &&
+              relTags["restriction:conditional"].indexOf("no_u_turn") > -1);
           // Case3: When a oneway road has no_u_turn via=node
-          if (restriction &&
-            simVia.type === 'node' &&
-            from.properties['@id'] === to.properties['@id'] &&
-            (from.properties.oneway && (from.properties.oneway === 'yes' || from.properties.oneway === '1' || from.properties.oneway === '-1'))) {
-            flag = true
+          if (
+            restriction &&
+            simVia.type === "node" &&
+            from.properties["@id"] === to.properties["@id"] &&
+            (from.properties.oneway &&
+              (from.properties.oneway === "yes" ||
+                from.properties.oneway === "1" ||
+                from.properties.oneway === "-1"))
+          ) {
+            flag = true;
           }
           // Case4: When a oneway road has no_u_turn via=line
-          var viaCoords = _.unique(_.flatten([simVia.start, simVia.end]))
-          if (restriction &&
-            simVia.type === 'line' &&
-            (_.intersection(simFrom.end, viaCoords).length === 2 && _.intersection(simTo.end, viaCoords).length === 2) &&
-            (from.properties.oneway && (from.properties.oneway === 'yes' || from.properties.oneway === '1')) &&
-            (to.properties.oneway && (to.properties.oneway === 'yes' || from.properties.oneway === '1'))) {
-            flag = true
+          var viaCoords = _.unique(_.flatten([simVia.start, simVia.end]));
+          if (
+            restriction &&
+            simVia.type === "line" &&
+            (_.intersection(simFrom.end, viaCoords).length === 2 &&
+              _.intersection(simTo.end, viaCoords).length === 2) &&
+            (from.properties.oneway &&
+              (from.properties.oneway === "yes" ||
+                from.properties.oneway === "1")) &&
+            (to.properties.oneway &&
+              (to.properties.oneway === "yes" ||
+                from.properties.oneway === "1"))
+          ) {
+            flag = true;
           }
           // Case5: When a oneway road has no_u_turn via=node
-          if (restriction &&
-            simVia.type === 'node' &&
-            (_.intersection(simFrom.end, viaCoords).length === 2 && _.intersection(simTo.end, viaCoords).length === 2) &&
-            (from.properties.oneway && (from.properties.oneway === 'yes' || from.properties.oneway === '1')) &&
-            (to.properties.oneway && (to.properties.oneway === 'yes' || from.properties.oneway === '1'))) {
-            flag = true
+          if (
+            restriction &&
+            simVia.type === "node" &&
+            (_.intersection(simFrom.end, viaCoords).length === 2 &&
+              _.intersection(simTo.end, viaCoords).length === 2) &&
+            (from.properties.oneway &&
+              (from.properties.oneway === "yes" ||
+                from.properties.oneway === "1")) &&
+            (to.properties.oneway &&
+              (to.properties.oneway === "yes" ||
+                from.properties.oneway === "1"))
+          ) {
+            flag = true;
           }
         }
 
         if (flag) {
           var fc = {
-            type: 'FeatureCollection',
+            type: "FeatureCollection",
             features: relationMembers[rel]
-          }
-          var line = turf.polygonToLineString(turf.bboxPolygon(turf.bbox(fc)))
-          line.properties = _.extend(relations[rel].props, {
-            members: relations[rel].members
-          }, relations[rel].tags, {
-            relations: relationMembers[rel]
-          }, {
+          };
+          fc.name = _.extend({
             _osmlint: osmlint
-          })
-          wstream.write(JSON.stringify(line) + '\n')
+          });
+          wstream.write(JSON.stringify(fc) + "\n");
         }
       }
     }
-  })
+  });
 
-  handlerA.end()
-  handlerB.end()
-  handlerC.end()
-  wstream.end()
-  wstream.on('close', callback)
-}
+  handlerA.end();
+  handlerB.end();
+  handlerC.end();
+  wstream.end();
+  wstream.on("close", callback);
+};

--- a/test/excessiveRolesTR.test.js
+++ b/test/excessiveRolesTR.test.js
@@ -1,28 +1,36 @@
-'use strict'
-var test = require('tape')
-var path = require('path')
-var readline = require('readline')
-var fs = require('fs')
-var processors = require('../index.js')
-var osm = path.join(__dirname, '/fixtures/excessiveRolesTR.osm')
-var outputFile = path.join(__dirname, '/fixtures/excessiveRolesTR.output.json')
-test('Excessive roles in TR', function (t) {
-  t.plan(2)
-  processors.excessiveRolesTR(null, osm, outputFile, function () {
-    var flag = true
+"use strict";
+var test = require("tape");
+var path = require("path");
+var readline = require("readline");
+var fs = require("fs");
+var processors = require("../index.js");
+var osm = path.join(__dirname, "/fixtures/excessiveRolesTR.osm");
+var outputFile = path.join(__dirname, "/fixtures/excessiveRolesTR.output.json");
+test("Excessive roles in TR", function(t) {
+  t.plan(2);
+  processors.excessiveRolesTR(null, osm, outputFile, function() {
+    var flag = true;
     var rd = readline.createInterface({
       input: fs.createReadStream(outputFile),
       output: process.stdout,
       terminal: false
-    })
-    rd.on('line', function (line) {
+    });
+    rd.on("line", function(line) {
       if (flag) {
-        flag = false
-        var feature = JSON.parse(line)
-        t.equal(feature.properties['@id'], 6502134, 'Should be 3858794')
-        t.equal(feature.properties._osmlint, 'excessiverolestr', 'Should be excessiverolestr')
-        t.end()
+        flag = false;
+        var feature = JSON.parse(line);
+        t.equal(
+          feature.features[0].properties["@idrel"],
+          6502134,
+          "Should be 6502134"
+        );
+        t.equal(
+          feature.name._osmlint,
+          "excessiverolestr",
+          "Should be excessiverolestr"
+        );
+        t.end();
       }
-    })
-  })
-})
+    });
+  });
+});

--- a/test/invalidRoleTR.test.js
+++ b/test/invalidRoleTR.test.js
@@ -1,28 +1,36 @@
-'use strict'
-var test = require('tape')
-var path = require('path')
-var readline = require('readline')
-var fs = require('fs')
-var processors = require('../index.js')
-var osm = path.join(__dirname, '/fixtures/invalidRoleTR.osm')
-var outputFile = path.join(__dirname, '/fixtures/invalidRoleTR.output.json')
-test('Invalid role in TR', function (t) {
-  t.plan(2)
-  processors.invalidRoleTR(null, osm, outputFile, function () {
-    var flag = true
+"use strict";
+var test = require("tape");
+var path = require("path");
+var readline = require("readline");
+var fs = require("fs");
+var processors = require("../index.js");
+var osm = path.join(__dirname, "/fixtures/invalidRoleTR.osm");
+var outputFile = path.join(__dirname, "/fixtures/invalidRoleTR.output.json");
+test("Invalid role in TR", function(t) {
+  t.plan(2);
+  processors.invalidRoleTR(null, osm, outputFile, function() {
+    var flag = true;
     var rd = readline.createInterface({
       input: fs.createReadStream(outputFile),
       output: process.stdout,
       terminal: false
-    })
-    rd.on('line', function (line) {
+    });
+    rd.on("line", function(line) {
       if (flag) {
-        flag = false
-        var feature = JSON.parse(line)
-        t.equal(feature.properties['@id'], 3871355, 'Should be 3871355')
-        t.equal(feature.properties._osmlint, 'invalidroletr', 'Should be invalidroletr')
-        t.end()
+        flag = false;
+        var feature = JSON.parse(line);
+        t.equal(
+          feature.features[0].properties["@idrel"],
+          3871355,
+          "Should be 3871355"
+        );
+        t.equal(
+          feature.name._osmlint,
+          "invalidroletr",
+          "Should be invalidroletr"
+        );
+        t.end();
       }
-    })
-  })
-})
+    });
+  });
+});

--- a/test/missingRoleTR.test.js
+++ b/test/missingRoleTR.test.js
@@ -1,28 +1,36 @@
-'use strict'
-var test = require('tape')
-var path = require('path')
-var readline = require('readline')
-var fs = require('fs')
-var processors = require('../index.js')
-var osm = path.join(__dirname, '/fixtures/missingRoleTR.osm')
-var outputFile = path.join(__dirname, '/fixtures/missingRoleTR.output.json')
-test('Missing role in TR', function (t) {
-  t.plan(2)
-  processors.missingRoleTR(null, osm, outputFile, function () {
-    var flag = true
+"use strict";
+var test = require("tape");
+var path = require("path");
+var readline = require("readline");
+var fs = require("fs");
+var processors = require("../index.js");
+var osm = path.join(__dirname, "/fixtures/missingRoleTR.osm");
+var outputFile = path.join(__dirname, "/fixtures/missingRoleTR.output.json");
+test("Missing role in TR", function(t) {
+  t.plan(2);
+  processors.missingRoleTR(null, osm, outputFile, function() {
+    var flag = true;
     var rd = readline.createInterface({
       input: fs.createReadStream(outputFile),
       output: process.stdout,
       terminal: false
-    })
-    rd.on('line', function (line) {
+    });
+    rd.on("line", function(line) {
       if (flag) {
-        flag = false
-        var feature = JSON.parse(line)
-        t.equal(feature.properties['@id'], 3858794, 'Should be 3858794')
-        t.equal(feature.properties._osmlint, 'missingroletr', 'Should be missingroletr')
-        t.end()
+        flag = false;
+        var feature = JSON.parse(line);
+        t.equal(
+          feature.features[0].properties["@idrel"],
+          3858794,
+          "Should be 3858794"
+        );
+        t.equal(
+          feature.name._osmlint,
+          "missingroletr",
+          "Should be missingroletr"
+        );
+        t.end();
       }
-    })
-  })
-})
+    });
+  });
+});

--- a/test/missingTypeRestrictionTR.test.js
+++ b/test/missingTypeRestrictionTR.test.js
@@ -1,28 +1,39 @@
-'use strict'
-var test = require('tape')
-var path = require('path')
-var readline = require('readline')
-var fs = require('fs')
-var processors = require('../index.js')
-var osm = path.join(__dirname, '/fixtures/missingTypeRestrictionTR.osm')
-var outputFile = path.join(__dirname, '/fixtures/missingTypeRestrictionTR.output.json')
-test('Missing type in restriction TR', function (t) {
-  t.plan(2)
-  processors.missingTypeRestrictionTR(null, osm, outputFile, function () {
-    var flag = true
+"use strict";
+var test = require("tape");
+var path = require("path");
+var readline = require("readline");
+var fs = require("fs");
+var processors = require("../index.js");
+var osm = path.join(__dirname, "/fixtures/missingTypeRestrictionTR.osm");
+var outputFile = path.join(
+  __dirname,
+  "/fixtures/missingTypeRestrictionTR.output.json"
+);
+test("Missing type in restriction TR", function(t) {
+  t.plan(2);
+  processors.missingTypeRestrictionTR(null, osm, outputFile, function() {
+    var flag = true;
     var rd = readline.createInterface({
       input: fs.createReadStream(outputFile),
       output: process.stdout,
       terminal: false
-    })
-    rd.on('line', function (line) {
+    });
+    rd.on("line", function(line) {
       if (flag) {
-        flag = false
-        var feature = JSON.parse(line)
-        t.equal(feature.properties['@id'], 1655470, 'Should be 1655470')
-        t.equal(feature.properties._osmlint, 'missingtyperestrictiontr', 'Should be missingTypeRestrictionTR')
-        t.end()
+        flag = false;
+        var feature = JSON.parse(line);
+        t.equal(
+          feature.features[0].properties["@idrel"],
+          1655470,
+          "Should be 1655470"
+        );
+        t.equal(
+          feature.name._osmlint,
+          "missingtyperestrictiontr",
+          "Should be missingTypeRestrictionTR"
+        );
+        t.end();
       }
-    })
-  })
-})
+    });
+  });
+});

--- a/test/redundantTROneway.test.js
+++ b/test/redundantTROneway.test.js
@@ -1,28 +1,39 @@
-'use strict'
-var test = require('tape')
-var path = require('path')
-var readline = require('readline')
-var fs = require('fs')
-var processors = require('../index.js')
-var osm = path.join(__dirname, '/fixtures/redundantTROneway.osm')
-var outputFile = path.join(__dirname, '/fixtures/redundantTROneway.output.json')
-test('redundant TR in oneways', function (t) {
-  t.plan(2)
-  processors.redundantTROneway(null, osm, outputFile, function () {
-    var flag = true
+"use strict";
+var test = require("tape");
+var path = require("path");
+var readline = require("readline");
+var fs = require("fs");
+var processors = require("../index.js");
+var osm = path.join(__dirname, "/fixtures/redundantTROneway.osm");
+var outputFile = path.join(
+  __dirname,
+  "/fixtures/redundantTROneway.output.json"
+);
+test("redundant TR in oneways", function(t) {
+  t.plan(2);
+  processors.redundantTROneway(null, osm, outputFile, function() {
+    var flag = true;
     var rd = readline.createInterface({
       input: fs.createReadStream(outputFile),
       output: process.stdout,
       terminal: false
-    })
-    rd.on('line', function (line) {
+    });
+    rd.on("line", function(line) {
       if (flag) {
-        flag = false
-        var feature = JSON.parse(line)
-        t.equal(feature.properties['@id'], 7496343, 'Should be 7496343')
-        t.equal(feature.properties._osmlint, 'redundanttroneway', 'Should be redundanttroneway')
-        t.end()
+        flag = false;
+        var feature = JSON.parse(line);
+        t.equal(
+          feature.features[0].properties["@idrel"],
+          7496343,
+          "Should be 7496343"
+        );
+        t.equal(
+          feature.name._osmlint,
+          "redundanttroneway",
+          "Should be redundanttroneway"
+        );
+        t.end();
       }
-    })
-  })
-})
+    });
+  });
+});


### PR DESCRIPTION
From https://github.com/osmlab/osmlint-osmium/issues/15

- Have the output only generate the features related to relation and remove properties which are not needed - sample [`output.json`](https://gist.github.com/srividyacb/887c529019767c7cd10c5e8662fed07c)
- Output of the linter will have name of the relation outside the feature.

```
"name": {
    "_osmlint": "excessiverolestr"
  }
```
- Added these changes to logical check linters

```
excessiveRolesTR
invalidRoleTR
missingRoleTR
missingTypeRestrictionTR
redundantTROneway
```

cc @maning @Ramshackle-Jamathon 

